### PR TITLE
Do not use crystal as tiered chest (non-GTNH environments)

### DIFF
--- a/src/main/java/cpw/mods/ironchest/IronChestType.java
+++ b/src/main/java/cpw/mods/ironchest/IronChestType.java
@@ -37,7 +37,7 @@ public enum IronChestType {
             TileEntityCopperChest.class, "mmmmCmmmm"),
     STEEL(72, 9, false, "Steel Chest", "silverchest.png", 4, Arrays.asList("ingotSteel"), TileEntitySteelChest.class,
             "mmmm3mmmm", "mGmG0GmGm"),
-    CRYSTAL(108, 12, true, "Crystal Chest", "crystalchest.png", 5, Arrays.asList("blockGlass"),
+    CRYSTAL(108, 12, false, "Crystal Chest", "crystalchest.png", 5, Arrays.asList("blockGlass"),
             TileEntityCrystalChest.class, "GGGGPGGGG"),
     OBSIDIAN(108, 12, false, "Obsidian Chest", "obsidianchest.png", 6, Arrays.asList("obsidian"),
             TileEntityObsidianChest.class, "mmmm2mmmm"),


### PR DESCRIPTION
The textures of the upgrades and the functionality is even "diamond to darksteel/netherite" and not "crystal to...".

As this only affects recipes, this only takes affect outside of GTNH modpack.

Before:
![grafik](https://github.com/GTNewHorizons/ironchest/assets/23138465/72985b52-3780-432c-81ef-d7ef20ef3258)

After:
![grafik](https://github.com/GTNewHorizons/ironchest/assets/23138465/9eedc20d-57bb-4a0a-9737-b7d5fe565da4)
