### PR TITLE
Add Localization

### DIFF
--- a/src/main/resources/assets/ironchest/lang/en_US.lang
+++ b/src/main/resources/assets/ironchest/lang/en_US.lang
@@ -1,3 +1,4 @@
+tile.IronChest.name=Chest
 tile.ironchest:IRON.name=Iron Chest
 tile.ironchest:GOLD.name=Gold Chest
 tile.ironchest:DIAMOND.name=Diamond Chest


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.