### PR TITLE
WDMla compat

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,5 +2,6 @@
 
 dependencies {
     compileOnly("com.github.GTNewHorizons:inventory-tweaks:1.7.1:api")
+    compileOnly("com.github.GTNewHorizons:WDMla:2.5.0:dev")
     implementation('com.github.GTNewHorizons:NotEnoughItems:2.7.29-GTNH:dev')
 }

--- a/src/main/java/cpw/mods/ironchest/plugins/wdmla/IronChestPlugin.java
+++ b/src/main/java/cpw/mods/ironchest/plugins/wdmla/IronChestPlugin.java
@@ -1,0 +1,17 @@
+package cpw.mods.ironchest.plugins.wdmla;
+
+import com.gtnewhorizons.wdmla.api.IWDMlaCommonRegistration;
+import com.gtnewhorizons.wdmla.api.IWDMlaPlugin;
+import com.gtnewhorizons.wdmla.api.WDMlaPlugin;
+import com.gtnewhorizons.wdmla.plugin.universal.ItemStorageProvider;
+
+import cpw.mods.ironchest.BlockIronChest;
+
+@WDMlaPlugin(uid = "ironchest")
+public class IronChestPlugin implements IWDMlaPlugin {
+
+    @Override
+    public void register(IWDMlaCommonRegistration registration) {
+        registration.registerItemStorage(ItemStorageProvider.Extension.INSTANCE, BlockIronChest.class);
+    }
+}


### PR DESCRIPTION
This PR is not ready until WDMla is put in the pack.

It explicitly states WDMla can display IronChest storage content without worrying the conflict with Waila