### PR TITLE
Implemented Ocelots sitting on Iron Chests, with configurable chest-blocking behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .gradle
 .settings
 /.idea/
+/.vscode/
 /run/
 /build/
 /eclipse/
@@ -25,7 +26,13 @@ whitelist.json
 *.iml
 *.ipr
 *.iws
-src/main/resources/mixins.*.json
+src/main/resources/mixins.*([!.]).json
 *.bat
 *.DS_Store
 !gradlew.bat
+.factorypath
+addon.local.gradle
+addon.local.gradle.kts
+addon.late.local.gradle
+addon.late.local.gradle.kts
+layout.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .gradle
 .settings
 /.idea/
-/.vscode/
 /run/
 /build/
 /eclipse/
@@ -26,13 +25,7 @@ whitelist.json
 *.iml
 *.ipr
 *.iws
-src/main/resources/mixins.*([!.]).json
+src/main/resources/mixins.*.json
 *.bat
 *.DS_Store
 !gradlew.bat
-.factorypath
-addon.local.gradle
-addon.local.gradle.kts
-addon.late.local.gradle
-addon.late.local.gradle.kts
-layout.json

--- a/gradle.properties
+++ b/gradle.properties
@@ -80,7 +80,7 @@ apiPackage =
 # Specify the configuration file for Forge's access transformers here. It must be placed into /src/main/resources/META-INF/
 # There can be multiple files in a space-separated list.
 # Example value: mymodid_at.cfg nei_at.cfg
-accessTransformersFile =
+accessTransformersFile = IronChest_at.cfg
 
 # Provides setup for Mixins if enabled. If you don't know what mixins are: Keep it disabled!
 usesMixins = false

--- a/src/main/java/cpw/mods/ironchest/BlockIronChest.java
+++ b/src/main/java/cpw/mods/ironchest/BlockIronChest.java
@@ -290,6 +290,8 @@ public class BlockIronChest extends BlockContainer {
     }
 
     private static boolean isOcelotSitting(World world, int x, int y, int z) {
+        if(!IronChest.OCELOTS_BLOCKCHESTS) return false;
+
         @SuppressWarnings("unchecked")
         List<EntityOcelot> cats = world.getEntitiesWithinAABB(EntityOcelot.class, AxisAlignedBB.getBoundingBox(
             (double)x, (double)(y + 1), (double)z, (double)(x + 1), (double)(y + 2), (double)(z + 1)));

--- a/src/main/java/cpw/mods/ironchest/BlockIronChest.java
+++ b/src/main/java/cpw/mods/ironchest/BlockIronChest.java
@@ -22,6 +22,7 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
+import net.minecraft.entity.passive.EntityOcelot;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.IInventory;
@@ -29,6 +30,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
@@ -116,6 +118,12 @@ public class BlockIronChest extends BlockContainer {
         }
 
         if (world.isRemote) {
+            return true;
+        }
+
+        if (isOcelotSitting(world, i, j, k)) {
+            // One or more Ocelots are sitting on this chest. Return true as if the player successfully used the chest,
+            // but don't open the chest!
             return true;
         }
 
@@ -278,6 +286,21 @@ public class BlockIronChest extends BlockContainer {
             }
             return true;
         }
+        return false;
+    }
+
+    private static boolean isOcelotSitting(World world, int x, int y, int z) {
+        @SuppressWarnings("unchecked")
+        List<EntityOcelot> cats = world.getEntitiesWithinAABB(EntityOcelot.class, AxisAlignedBB.getBoundingBox(
+            (double)x, (double)(y + 1), (double)z, (double)(x + 1), (double)(y + 2), (double)(z + 1)));
+        for(EntityOcelot cat : cats) {
+            if(cat.isSitting()) {
+                // There are cats in the block above this chest and at least one of them is sitting.
+                return true;
+            }
+        }
+
+        // No cats or none of them are sitting. :(
         return false;
     }
 

--- a/src/main/java/cpw/mods/ironchest/BlockIronChest.java
+++ b/src/main/java/cpw/mods/ironchest/BlockIronChest.java
@@ -290,13 +290,20 @@ public class BlockIronChest extends BlockContainer {
     }
 
     private static boolean isOcelotSitting(World world, int x, int y, int z) {
-        if(!IronChest.OCELOTS_BLOCKCHESTS) return false;
+        if (!IronChest.OCELOTS_BLOCKCHESTS) return false;
 
         @SuppressWarnings("unchecked")
-        List<EntityOcelot> cats = world.getEntitiesWithinAABB(EntityOcelot.class, AxisAlignedBB.getBoundingBox(
-            (double)x, (double)(y + 1), (double)z, (double)(x + 1), (double)(y + 2), (double)(z + 1)));
-        for(EntityOcelot cat : cats) {
-            if(cat.isSitting()) {
+        List<EntityOcelot> cats = world.getEntitiesWithinAABB(
+                EntityOcelot.class,
+                AxisAlignedBB.getBoundingBox(
+                        (double) x,
+                        (double) (y + 1),
+                        (double) z,
+                        (double) (x + 1),
+                        (double) (y + 2),
+                        (double) (z + 1)));
+        for (EntityOcelot cat : cats) {
+            if (cat.isSitting()) {
                 // There are cats in the block above this chest and at least one of them is sitting.
                 return true;
             }

--- a/src/main/java/cpw/mods/ironchest/IronChest.java
+++ b/src/main/java/cpw/mods/ironchest/IronChest.java
@@ -59,10 +59,18 @@ public class IronChest {
         try {
             cfg.load();
             CACHE_RENDER = cfg.get(Configuration.CATEGORY_GENERAL, "cacheRenderingInformation", true).getBoolean(true);
-            OCELOTS_SITONCHESTS = cfg.get(Configuration.CATEGORY_GENERAL, "ocelotsSitOnChests", true,
+            OCELOTS_SITONCHESTS = cfg.get(
+                    Configuration.CATEGORY_GENERAL,
+                    "ocelotsSitOnChests",
+                    true,
                     "Whether or not to allow Ocelots to sit on Iron Chests.").getBoolean(true);
-            OCELOTS_BLOCKCHESTS = cfg.get(Configuration.CATEGORY_GENERAL, "ocelotsBlockChests", true,
-                    "Whether or not Ocelots should prevent opening Iron Chests when sitting on top of them.").getBoolean(true);
+            OCELOTS_BLOCKCHESTS = cfg
+                    .get(
+                            Configuration.CATEGORY_GENERAL,
+                            "ocelotsBlockChests",
+                            true,
+                            "Whether or not Ocelots should prevent opening Iron Chests when sitting on top of them.")
+                    .getBoolean(true);
             TRANSPARENT_RENDER_INSIDE = cfg.get(Configuration.CATEGORY_GENERAL, "transparentRenderInside", true)
                     .getBoolean(true);
             TRANSPARENT_RENDER_DISTANCE = cfg.get(Configuration.CATEGORY_GENERAL, "transparentRenderDistance", 128D)

--- a/src/main/java/cpw/mods/ironchest/IronChest.java
+++ b/src/main/java/cpw/mods/ironchest/IronChest.java
@@ -107,10 +107,9 @@ public class IronChest {
         ChestChangerType.generateRecipes();
         NetworkRegistry.INSTANCE.registerGuiHandler(instance, proxy);
         proxy.registerRenderInformation();
-        // if (OCELOTS_SITONCHESTS)
-        // {
-        // MinecraftForge.EVENT_BUS.register(new OcelotsSitOnChestsHandler());
-        // }
+        if (OCELOTS_SITONCHESTS) {
+            MinecraftForge.EVENT_BUS.register(new OcelotsSitOnChestsHandler());
+        }
         MinecraftForge.EVENT_BUS.register(this);
     }
 

--- a/src/main/java/cpw/mods/ironchest/IronChest.java
+++ b/src/main/java/cpw/mods/ironchest/IronChest.java
@@ -41,6 +41,7 @@ public class IronChest {
     public static IronChest instance;
     public static boolean CACHE_RENDER = true;
     public static boolean OCELOTS_SITONCHESTS = true;
+    public static boolean OCELOTS_BLOCKCHESTS = true;
     public static final String VERSION = "GRADLETOKEN_VERSION";
     public static boolean TRANSPARENT_RENDER_INSIDE = true;
     public static double TRANSPARENT_RENDER_DISTANCE = 128D;
@@ -58,7 +59,10 @@ public class IronChest {
         try {
             cfg.load();
             CACHE_RENDER = cfg.get(Configuration.CATEGORY_GENERAL, "cacheRenderingInformation", true).getBoolean(true);
-            OCELOTS_SITONCHESTS = cfg.get(Configuration.CATEGORY_GENERAL, "ocelotsSitOnChests", true).getBoolean(true);
+            OCELOTS_SITONCHESTS = cfg.get(Configuration.CATEGORY_GENERAL, "ocelotsSitOnChests", true,
+                    "Whether or not to allow Ocelots to sit on Iron Chests.").getBoolean(true);
+            OCELOTS_BLOCKCHESTS = cfg.get(Configuration.CATEGORY_GENERAL, "ocelotsBlockChests", true,
+                    "Whether or not Ocelots should prevent opening Iron Chests when sitting on top of them.").getBoolean(true);
             TRANSPARENT_RENDER_INSIDE = cfg.get(Configuration.CATEGORY_GENERAL, "transparentRenderInside", true)
                     .getBoolean(true);
             TRANSPARENT_RENDER_DISTANCE = cfg.get(Configuration.CATEGORY_GENERAL, "transparentRenderDistance", 128D)

--- a/src/main/java/cpw/mods/ironchest/IronChestAIOcelotSit.java
+++ b/src/main/java/cpw/mods/ironchest/IronChestAIOcelotSit.java
@@ -1,5 +1,6 @@
 package cpw.mods.ironchest;
 
+import net.minecraft.block.Block;
 import net.minecraft.entity.ai.EntityAIOcelotSit;
 import net.minecraft.entity.passive.EntityOcelot;
 import net.minecraft.world.World;
@@ -11,8 +12,12 @@ public class IronChestAIOcelotSit extends EntityAIOcelotSit {
     }
 
     @Override public boolean func_151486_a(World world, int x, int y, int z) {
-        if (world.getBlock(x, y, z) == IronChest.ironChestBlock) {
-            return true;
+        Block targetBlock = world.getBlock(x, y, z);
+        if (targetBlock == IronChest.ironChestBlock) {
+            TileEntityIronChest chest = (TileEntityIronChest)world.getTileEntity(x, y, z);
+            if(chest.getNumUsingPlayers() == 0) {
+                return true;
+            }
         }
         return super.func_151486_a(world, x, y, z);
     }

--- a/src/main/java/cpw/mods/ironchest/IronChestAIOcelotSit.java
+++ b/src/main/java/cpw/mods/ironchest/IronChestAIOcelotSit.java
@@ -2,6 +2,7 @@ package cpw.mods.ironchest;
 
 import net.minecraft.entity.ai.EntityAIOcelotSit;
 import net.minecraft.entity.passive.EntityOcelot;
+import net.minecraft.world.World;
 
 public class IronChestAIOcelotSit extends EntityAIOcelotSit {
 
@@ -9,7 +10,10 @@ public class IronChestAIOcelotSit extends EntityAIOcelotSit {
         super(par1EntityOcelot, par2);
     }
 
-    /*
-     * @Override protected boolean func_151486_a(World world, int x, int y, int z) { if (world.getBlock(x, y, z) ==
-     * IronChest.ironChestBlock) { return true; } return super.func_151486_a(world, x, y, z); }
-     */}
+    @Override public boolean func_151486_a(World world, int x, int y, int z) {
+        if (world.getBlock(x, y, z) == IronChest.ironChestBlock) {
+            return true;
+        }
+        return super.func_151486_a(world, x, y, z);
+    }
+}

--- a/src/main/java/cpw/mods/ironchest/IronChestAIOcelotSit.java
+++ b/src/main/java/cpw/mods/ironchest/IronChestAIOcelotSit.java
@@ -11,11 +11,12 @@ public class IronChestAIOcelotSit extends EntityAIOcelotSit {
         super(ocelot, navigationSpeed);
     }
 
-    @Override public boolean func_151486_a(World world, int x, int y, int z) {
+    @Override
+    public boolean func_151486_a(World world, int x, int y, int z) {
         Block targetBlock = world.getBlock(x, y, z);
         if (targetBlock == IronChest.ironChestBlock) {
-            TileEntityIronChest chest = (TileEntityIronChest)world.getTileEntity(x, y, z);
-            if(chest.getNumUsingPlayers() == 0) {
+            TileEntityIronChest chest = (TileEntityIronChest) world.getTileEntity(x, y, z);
+            if (chest.getNumUsingPlayers() == 0) {
                 return true;
             }
         }

--- a/src/main/java/cpw/mods/ironchest/IronChestAIOcelotSit.java
+++ b/src/main/java/cpw/mods/ironchest/IronChestAIOcelotSit.java
@@ -6,8 +6,8 @@ import net.minecraft.world.World;
 
 public class IronChestAIOcelotSit extends EntityAIOcelotSit {
 
-    public IronChestAIOcelotSit(EntityOcelot par1EntityOcelot, float par2) {
-        super(par1EntityOcelot, par2);
+    public IronChestAIOcelotSit(EntityOcelot ocelot, double navigationSpeed) {
+        super(ocelot, navigationSpeed);
     }
 
     @Override public boolean func_151486_a(World world, int x, int y, int z) {

--- a/src/main/java/cpw/mods/ironchest/OcelotsSitOnChestsHandler.java
+++ b/src/main/java/cpw/mods/ironchest/OcelotsSitOnChestsHandler.java
@@ -21,7 +21,7 @@ public class OcelotsSitOnChestsHandler {
             for (EntityAITasks.EntityAITaskEntry task : tasks) {
                 if (task.priority == 6 && (task.action instanceof EntityAIOcelotSit)
                         && !(task.action instanceof IronChestAIOcelotSit)) {
-                    task.action = new IronChestAIOcelotSit(ocelot, 0.4F);
+                    task.action = new IronChestAIOcelotSit(ocelot, 1.33D);
                 }
             }
         }

--- a/src/main/java/cpw/mods/ironchest/TileEntityIronChest.java
+++ b/src/main/java/cpw/mods/ironchest/TileEntityIronChest.java
@@ -69,6 +69,10 @@ public class TileEntityIronChest extends TileEntity implements IInventory {
         return type;
     }
 
+    public int getNumUsingPlayers() {
+        return numUsingPlayers;
+    }
+
     @Override
     public ItemStack getStackInSlot(int i) {
         inventoryTouched = true;

--- a/src/main/resources/META-INF/IronChest_at.cfg
+++ b/src/main/resources/META-INF/IronChest_at.cfg
@@ -1,0 +1,1 @@
+public	net.minecraft.entity.ai.EntityAIOcelotSit	func_151486_a(Lnet/minecraft/world/World;III)Z # isSittableBlock


### PR DESCRIPTION
This PR implements the missing functionality of Ocelots being able to sit on Iron Chests. It appears to have been planned (fb8ad04f) but was never implemented.

In addition to the basic pathfinding functionality, an Iron Chest is now prevented from opening if an Ocelot is sitting on top of it. This behavior can be turned off with a new configuration option.

Here's a fancy demonstration video: https://files.catbox.moe/o36923.mp4