### PR TITLE
Small cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .gradle
 .settings
 /.idea/
+/.vscode/
 /run/
 /build/
 /eclipse/
@@ -25,7 +26,13 @@ whitelist.json
 *.iml
 *.ipr
 *.iws
-src/main/resources/mixins.*.json
+src/main/resources/mixins.*([!.]).json
 *.bat
 *.DS_Store
 !gradlew.bat
+.factorypath
+addon.local.gradle
+addon.local.gradle.kts
+addon.late.local.gradle
+addon.late.local.gradle.kts
+layout.json

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,5 +2,5 @@
 
 dependencies {
     compileOnly("com.github.GTNewHorizons:inventory-tweaks:1.7.1:api")
-    implementation('com.github.GTNewHorizons:NotEnoughItems:2.7.51-GTNH:dev')
+    implementation('com.github.GTNewHorizons:NotEnoughItems:2.7.58-GTNH:dev')
 }

--- a/src/main/java/cpw/mods/ironchest/IronChest.java
+++ b/src/main/java/cpw/mods/ironchest/IronChest.java
@@ -59,9 +59,18 @@ public class IronChest {
             cfg.load();
             CACHE_RENDER = cfg.get(Configuration.CATEGORY_GENERAL, "cacheRenderingInformation", true).getBoolean(true);
             OCELOTS_SITONCHESTS = cfg.get(Configuration.CATEGORY_GENERAL, "ocelotsSitOnChests", true).getBoolean(true);
-            TRANSPARENT_RENDER_INSIDE = cfg.get(Configuration.CATEGORY_GENERAL, "transparentRenderInside", true)
+            TRANSPARENT_RENDER_INSIDE = cfg
+                    .get(
+                            Configuration.CATEGORY_GENERAL,
+                            "transparentRenderInside",
+                            true,
+                            "Whether or not transparent chests (i.e. crystal) should display their contents.")
                     .getBoolean(true);
-            TRANSPARENT_RENDER_DISTANCE = cfg.get(Configuration.CATEGORY_GENERAL, "transparentRenderDistance", 128D)
+            TRANSPARENT_RENDER_DISTANCE = cfg.get(
+                    Configuration.CATEGORY_GENERAL,
+                    "transparentRenderDistance",
+                    128D,
+                    "Maximum distance from a transparent chest, after which its contents will stop being displayed.")
                     .getDouble(128D);
             ENABLE_STEEL_CHESTS = cfg
                     .get(Configuration.CATEGORY_GENERAL, "enableSteelChests", true, "Enables the steel chest.")

--- a/src/main/java/cpw/mods/ironchest/IronChest.java
+++ b/src/main/java/cpw/mods/ironchest/IronChest.java
@@ -39,7 +39,6 @@ public class IronChest {
     public static CommonProxy proxy;
     @Instance("IronChest")
     public static IronChest instance;
-    public static boolean CACHE_RENDER = true;
     public static boolean OCELOTS_SITONCHESTS = true;
     public static final String VERSION = "GRADLETOKEN_VERSION";
     public static boolean TRANSPARENT_RENDER_INSIDE = true;
@@ -57,7 +56,6 @@ public class IronChest {
         Configuration cfg = new Configuration(event.getSuggestedConfigurationFile());
         try {
             cfg.load();
-            CACHE_RENDER = cfg.get(Configuration.CATEGORY_GENERAL, "cacheRenderingInformation", true).getBoolean(true);
             OCELOTS_SITONCHESTS = cfg.get(Configuration.CATEGORY_GENERAL, "ocelotsSitOnChests", true).getBoolean(true);
             TRANSPARENT_RENDER_INSIDE = cfg
                     .get(

--- a/src/main/java/cpw/mods/ironchest/IronChest.java
+++ b/src/main/java/cpw/mods/ironchest/IronChest.java
@@ -82,7 +82,7 @@ public class IronChest {
                     Configuration.CATEGORY_GENERAL,
                     "enableDarkSteelChests",
                     isGTNHLoaded,
-                    "Enables the dark steel.").getBoolean(isGTNHLoaded);
+                    "Enables the dark steel chest.").getBoolean(isGTNHLoaded);
             ENABLE_NETHERITE_CHESTS = cfg.get(
                     Configuration.CATEGORY_GENERAL,
                     "enableNetheriteChests",

--- a/src/main/java/cpw/mods/ironchest/client/TileEntityIronChestRenderer.java
+++ b/src/main/java/cpw/mods/ironchest/client/TileEntityIronChestRenderer.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Random;
 
 import net.minecraft.client.model.ModelChest;
-import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
@@ -63,7 +62,6 @@ public class TileEntityIronChestRenderer extends TileEntitySpecialRenderer {
     public TileEntityIronChestRenderer() {
         model = new ModelChest();
         random = new Random();
-        RenderBlocks renderBlocks = new RenderBlocks();
         itemRenderer = new RenderItem() {
 
             @Override


### PR DESCRIPTION
- Updated the .gitignore
- Ran `updateDependencies`
- Added missing configuration comments to `transparentRenderDistance` and `transparentRenderInside`
- Fixed a typo in another configuration comment (`enableDarkSteelChests`)
- Removed an unused local variable
- The configuration option `cacheRenderingInformation` is completely unused, so it has been removed